### PR TITLE
Update RNToasty.podspec 

### DIFF
--- a/ios/RNToasty.podspec
+++ b/ios/RNToasty.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNToasty
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/author/RNToasty.git"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
fix - With RN 0.60.3 can't install pod, because error: 'attributes: Missing required attribute `homepage`.'