### PR TITLE
Remove hardcoded duration for iOS.

### DIFF
--- a/ios/RNToasty.m
+++ b/ios/RNToasty.m
@@ -45,6 +45,10 @@ RCT_EXPORT_METHOD(Show:(NSDictionary *)props) {
         style.messageFont = [UIFont systemFontOfSize: [titleSize intValue]];
     }
 
+    if(duration != nil) {
+           duration = duration.intValue == 0 ? [NSNumber numberWithFloat:1.0] : [NSNumber numberWithFloat:3.0];
+    }
+    
     const NSString *toastPosition = [self getPosition: position];
     
     UIWindow *window = [[UIApplication sharedApplication] keyWindow];
@@ -52,7 +56,7 @@ RCT_EXPORT_METHOD(Show:(NSDictionary *)props) {
     // toast with all possible options
     [window
      makeToast: title
-     duration: 3.0
+     duration: duration.floatValue
      position: toastPosition
      title: nil
      image: drawable


### PR DESCRIPTION
The duration of the effect for iOS was 3 seconds.
As proposed in the documentation the values for prop "duration" to be 0 or 1 for short duration and long duration, I kept the value of 3 seconds for long duration and added the value of 1 second for short duration.

Issue: #4  