### PR TITLE
Fix tintColor android issue

### DIFF
--- a/js/RNToasty.js
+++ b/js/RNToasty.js
@@ -33,7 +33,7 @@ class Toasty extends PureComponent {
 
     title: '',
     titleSize: 0,
-    titleColor: '',
+    titleColor: '#ffffff',
 
     duration: 0,
 


### PR DESCRIPTION
The missing default prop of `titleColor` leads to error on Android OS when the `tintColor` is used. 
This PR solves the #36 and #29 issues. 

Until this PR is merged, a workaround could be the use of both titleColor and tintColor in the object props. 